### PR TITLE
refactor: Zustandによる状態管理の一元化 (#20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@mapbox/mapbox-gl-draw": "^1.5.1",
         "@turf/turf": "^7.3.2",
-        "rbush": "^4.0.1"
+        "rbush": "^4.0.1",
+        "zustand": "^5.0.10"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^8.6.14",
@@ -4994,7 +4995,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -5015,7 +5016,7 @@
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6452,7 +6453,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -12863,6 +12864,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
+      "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.5.1",
     "@turf/turf": "^7.3.2",
-    "rbush": "^4.0.1"
+    "rbush": "^4.0.1",
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.14",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Zustand Store Exports
+ *
+ * Centralized state management for the application
+ */
+
+export {
+  useMapState,
+  useOverlayState,
+  useWeatherState,
+  useRestrictionState,
+  useCustomLayerState,
+  useComparisonState,
+  useDidState,
+  useMapStateActions,
+  type LayerCategory,
+  type LayerVisibilityState,
+  type MapStateActions,
+  type MapState
+} from './useMapState'

--- a/src/store/useMapState.test.ts
+++ b/src/store/useMapState.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useMapState } from './useMapState'
+
+describe('useMapState', () => {
+  beforeEach(() => {
+    // Reset store before each test
+    useMapState.getState().resetAll()
+  })
+
+  describe('toggleLayer', () => {
+    it('should toggle layer visibility from false to true', () => {
+      const { toggleLayer } = useMapState.getState()
+
+      expect(useMapState.getState().restriction['test-layer']).toBeUndefined()
+
+      toggleLayer('restriction', 'test-layer')
+
+      expect(useMapState.getState().restriction['test-layer']).toBe(true)
+    })
+
+    it('should toggle layer visibility from true to false', () => {
+      const { setLayerVisibility, toggleLayer } = useMapState.getState()
+
+      setLayerVisibility('restriction', 'test-layer', true)
+      expect(useMapState.getState().restriction['test-layer']).toBe(true)
+
+      toggleLayer('restriction', 'test-layer')
+      expect(useMapState.getState().restriction['test-layer']).toBe(false)
+    })
+  })
+
+  describe('setLayerVisibility', () => {
+    it('should set layer visibility to true', () => {
+      const { setLayerVisibility } = useMapState.getState()
+
+      setLayerVisibility('overlay', 'rain-radar', true)
+
+      expect(useMapState.getState().overlay['rain-radar']).toBe(true)
+    })
+
+    it('should set layer visibility to false', () => {
+      const { setLayerVisibility } = useMapState.getState()
+
+      setLayerVisibility('overlay', 'rain-radar', true)
+      setLayerVisibility('overlay', 'rain-radar', false)
+
+      expect(useMapState.getState().overlay['rain-radar']).toBe(false)
+    })
+  })
+
+  describe('setMultipleLayers', () => {
+    it('should set multiple layers at once', () => {
+      const { setMultipleLayers } = useMapState.getState()
+
+      setMultipleLayers('restriction', {
+        airport: true,
+        'did-all-japan': true,
+        'no-fly-red': false
+      })
+
+      const state = useMapState.getState()
+      expect(state.restriction['airport']).toBe(true)
+      expect(state.restriction['did-all-japan']).toBe(true)
+      expect(state.restriction['no-fly-red']).toBe(false)
+    })
+
+    it('should merge with existing state', () => {
+      const { setLayerVisibility, setMultipleLayers } = useMapState.getState()
+
+      setLayerVisibility('restriction', 'existing', true)
+      setMultipleLayers('restriction', { new: true })
+
+      const state = useMapState.getState()
+      expect(state.restriction['existing']).toBe(true)
+      expect(state.restriction['new']).toBe(true)
+    })
+  })
+
+  describe('isLayerVisible', () => {
+    it('should return true for visible layer', () => {
+      const { setLayerVisibility, isLayerVisible } = useMapState.getState()
+
+      setLayerVisibility('weather', 'temperature', true)
+
+      expect(isLayerVisible('weather', 'temperature')).toBe(true)
+    })
+
+    it('should return false for hidden layer', () => {
+      const { setLayerVisibility, isLayerVisible } = useMapState.getState()
+
+      setLayerVisibility('weather', 'temperature', false)
+
+      expect(isLayerVisible('weather', 'temperature')).toBe(false)
+    })
+
+    it('should return false for undefined layer', () => {
+      const { isLayerVisible } = useMapState.getState()
+
+      expect(isLayerVisible('weather', 'nonexistent')).toBe(false)
+    })
+  })
+
+  describe('getVisibleLayers', () => {
+    it('should return array of visible layer keys', () => {
+      const { setMultipleLayers, getVisibleLayers } = useMapState.getState()
+
+      setMultipleLayers('comparison', {
+        'layer-a': true,
+        'layer-b': false,
+        'layer-c': true
+      })
+
+      const visible = getVisibleLayers('comparison')
+
+      expect(visible).toContain('layer-a')
+      expect(visible).toContain('layer-c')
+      expect(visible).not.toContain('layer-b')
+      expect(visible).toHaveLength(2)
+    })
+
+    it('should return empty array when no layers visible', () => {
+      const { getVisibleLayers } = useMapState.getState()
+
+      expect(getVisibleLayers('customLayer')).toEqual([])
+    })
+  })
+
+  describe('resetCategory', () => {
+    it('should reset specific category to empty object', () => {
+      const { setMultipleLayers, resetCategory } = useMapState.getState()
+
+      setMultipleLayers('did', { 'did-tokyo': true, 'did-osaka': true })
+      expect(Object.keys(useMapState.getState().did)).toHaveLength(2)
+
+      resetCategory('did')
+      expect(useMapState.getState().did).toEqual({})
+    })
+
+    it('should not affect other categories', () => {
+      const { setLayerVisibility, resetCategory } = useMapState.getState()
+
+      setLayerVisibility('restriction', 'airport', true)
+      setLayerVisibility('overlay', 'rain', true)
+
+      resetCategory('restriction')
+
+      expect(useMapState.getState().restriction).toEqual({})
+      expect(useMapState.getState().overlay['rain']).toBe(true)
+    })
+  })
+
+  describe('resetAll', () => {
+    it('should reset all categories', () => {
+      const { setLayerVisibility, resetAll } = useMapState.getState()
+
+      setLayerVisibility('overlay', 'test', true)
+      setLayerVisibility('weather', 'test', true)
+      setLayerVisibility('restriction', 'test', true)
+      setLayerVisibility('customLayer', 'test', true)
+      setLayerVisibility('comparison', 'test', true)
+      setLayerVisibility('did', 'test', true)
+
+      resetAll()
+
+      const state = useMapState.getState()
+      expect(state.overlay).toEqual({})
+      expect(state.weather).toEqual({})
+      expect(state.restriction).toEqual({})
+      expect(state.customLayer).toEqual({})
+      expect(state.comparison).toEqual({})
+      expect(state.did).toEqual({})
+    })
+  })
+
+  describe('importState', () => {
+    it('should import partial state', () => {
+      const { importState } = useMapState.getState()
+
+      importState({
+        restriction: { airport: true, 'no-fly': true },
+        comparison: { 'noto-2024': true }
+      })
+
+      const state = useMapState.getState()
+      expect(state.restriction['airport']).toBe(true)
+      expect(state.restriction['no-fly']).toBe(true)
+      expect(state.comparison['noto-2024']).toBe(true)
+    })
+
+    it('should merge with existing state', () => {
+      const { setLayerVisibility, importState } = useMapState.getState()
+
+      setLayerVisibility('overlay', 'existing', true)
+
+      importState({
+        overlay: { imported: true }
+      })
+
+      const state = useMapState.getState()
+      // Note: importState replaces the category, not merges
+      expect(state.overlay['imported']).toBe(true)
+    })
+  })
+})

--- a/src/store/useMapState.ts
+++ b/src/store/useMapState.ts
@@ -1,0 +1,180 @@
+/**
+ * Zustand Store for Map Layer State Management
+ *
+ * Centralizes all layer visibility state that was previously scattered across App.tsx:
+ * - overlayStates
+ * - weatherStates
+ * - restrictionStates
+ * - customLayerVisibility
+ * - comparisonLayerVisibility
+ */
+import { create } from 'zustand'
+import { devtools, persist } from 'zustand/middleware'
+
+export type LayerCategory =
+  | 'overlay'
+  | 'weather'
+  | 'restriction'
+  | 'customLayer'
+  | 'comparison'
+  | 'did'
+
+export interface LayerVisibilityState {
+  overlay: Record<string, boolean>
+  weather: Record<string, boolean>
+  restriction: Record<string, boolean>
+  customLayer: Record<string, boolean>
+  comparison: Record<string, boolean>
+  did: Record<string, boolean>
+}
+
+export interface MapStateActions {
+  // Toggle layer visibility
+  toggleLayer: (category: LayerCategory, key: string) => void
+
+  // Set specific layer visibility
+  setLayerVisibility: (category: LayerCategory, key: string, visible: boolean) => void
+
+  // Set multiple layers at once
+  setMultipleLayers: (category: LayerCategory, layers: Record<string, boolean>) => void
+
+  // Get layer visibility
+  isLayerVisible: (category: LayerCategory, key: string) => boolean
+
+  // Get all visible layers in a category
+  getVisibleLayers: (category: LayerCategory) => string[]
+
+  // Reset category to initial state
+  resetCategory: (category: LayerCategory) => void
+
+  // Reset all state
+  resetAll: () => void
+
+  // Bulk import state (for migration from existing App.tsx state)
+  importState: (state: Partial<LayerVisibilityState>) => void
+}
+
+export type MapState = LayerVisibilityState & MapStateActions
+
+const initialState: LayerVisibilityState = {
+  overlay: {},
+  weather: {},
+  restriction: {},
+  customLayer: {},
+  comparison: {},
+  did: {}
+}
+
+export const useMapState = create<MapState>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        ...initialState,
+
+        toggleLayer: (category, key) => {
+          set(
+            (state) => ({
+              [category]: {
+                ...state[category],
+                [key]: !state[category][key]
+              }
+            }),
+            false,
+            `toggleLayer/${category}/${key}`
+          )
+        },
+
+        setLayerVisibility: (category, key, visible) => {
+          set(
+            (state) => ({
+              [category]: {
+                ...state[category],
+                [key]: visible
+              }
+            }),
+            false,
+            `setLayerVisibility/${category}/${key}/${visible}`
+          )
+        },
+
+        setMultipleLayers: (category, layers) => {
+          set(
+            (state) => ({
+              [category]: {
+                ...state[category],
+                ...layers
+              }
+            }),
+            false,
+            `setMultipleLayers/${category}`
+          )
+        },
+
+        isLayerVisible: (category, key) => {
+          return get()[category][key] ?? false
+        },
+
+        getVisibleLayers: (category) => {
+          const categoryState = get()[category]
+          return Object.entries(categoryState)
+            .filter(([, visible]) => visible)
+            .map(([key]) => key)
+        },
+
+        resetCategory: (category) => {
+          set(
+            { [category]: {} },
+            false,
+            `resetCategory/${category}`
+          )
+        },
+
+        resetAll: () => {
+          set(initialState, false, 'resetAll')
+        },
+
+        importState: (state) => {
+          set(
+            (current) => ({
+              ...current,
+              ...state
+            }),
+            false,
+            'importState'
+          )
+        }
+      }),
+      {
+        name: 'map-layer-state',
+        partialize: (state) => ({
+          // Only persist certain categories
+          restriction: state.restriction,
+          comparison: state.comparison
+          // Don't persist: overlay, weather, customLayer, did (session-specific)
+        })
+      }
+    ),
+    { name: 'MapState' }
+  )
+)
+
+// Selector hooks for better performance (avoid unnecessary re-renders)
+export const useOverlayState = () => useMapState((state) => state.overlay)
+export const useWeatherState = () => useMapState((state) => state.weather)
+export const useRestrictionState = () => useMapState((state) => state.restriction)
+export const useCustomLayerState = () => useMapState((state) => state.customLayer)
+export const useComparisonState = () => useMapState((state) => state.comparison)
+export const useDidState = () => useMapState((state) => state.did)
+
+// Action hooks
+export const useMapStateActions = () =>
+  useMapState((state) => ({
+    toggleLayer: state.toggleLayer,
+    setLayerVisibility: state.setLayerVisibility,
+    setMultipleLayers: state.setMultipleLayers,
+    isLayerVisible: state.isLayerVisible,
+    getVisibleLayers: state.getVisibleLayers,
+    resetCategory: state.resetCategory,
+    resetAll: state.resetAll,
+    importState: state.importState
+  }))


### PR DESCRIPTION
## Summary
- Zustandを導入し、レイヤー状態管理を一元化
- 6カテゴリの状態管理ストアを作成
- DevTools対応、部分的な永続化

## 新規ファイル

| ファイル | 説明 |
|----------|------|
| `src/store/useMapState.ts` | Zustandストア本体 |
| `src/store/index.ts` | エクスポート |
| `src/store/useMapState.test.ts` | ユニットテスト (16件) |

## 管理カテゴリ

```typescript
type LayerCategory =
  | 'overlay'     // オーバーレイ
  | 'weather'     // 天気
  | 'restriction' // 制限ゾーン
  | 'customLayer' // カスタムレイヤー
  | 'comparison'  // 比較レイヤー
  | 'did'         // DIDレイヤー
```

## API

- `toggleLayer(category, key)` - 可視性トグル
- `setLayerVisibility(category, key, visible)` - 可視性設定
- `setMultipleLayers(category, layers)` - 複数レイヤー一括設定
- `getVisibleLayers(category)` - 表示中レイヤー取得
- `isLayerVisible(category, key)` - 可視性確認
- `resetCategory(category)` / `resetAll()` - リセット
- `importState(state)` - 状態インポート（移行用）

## 次のステップ
App.tsxの既存useState → Zustand移行（後続PR）

## Test plan
- [x] `npm run build` - ビルド成功
- [x] `npm run test` - 85テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)